### PR TITLE
Add repeated [MASK] classification example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Visit our [documentation](https://docs.vllm.ai/en/latest/) to learn more.
 - [Installation](https://docs.vllm.ai/en/latest/getting_started/installation.html)
 - [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html)
 - [List of Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html)
+- [Repeated `[MASK]` Classification Example](docs/source/models/pooling_models.md#repeated-mask-classification)
 
 ## Contributing
 

--- a/docs/source/models/pooling_models.md
+++ b/docs/source/models/pooling_models.md
@@ -111,6 +111,24 @@ print(f"Class Probabilities: {probs!r} (size={len(probs)})")
 
 A code example can be found here: <gh-file:examples/offline_inference/basic/classify.py>
 
+### Repeated `[MASK]` Classification
+
+You can use vLLM with encoder models in a decoder‑style loop. When a prompt
+consists of a static prefix followed by changing tokens and ends with a
+`[MASK]`, you may repeatedly call {meth}`~vllm.LLM.classify` to obtain the
+logits of that final token. Disabling softmax via
+`--override-pooler-config '{"softmax": false}'` yields raw logits, which can then
+be passed through a sigmoid to produce probabilities.
+
+An example script is provided at
+<gh-file:examples/offline_inference/token_mask_classification.py>:
+
+```bash
+python examples/offline_inference/token_mask_classification.py \
+  --static-prefix "<YOUR_PREFIX>" --variable-file dynamic.txt \
+  --iterations 1000
+```
+
 ### `LLM.score`
 
 The {class}`~vllm.LLM.score` method outputs similarity scores between sentence pairs.

--- a/examples/offline_inference/token_mask_classification.py
+++ b/examples/offline_inference/token_mask_classification.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Example for repeated token classification on the last [MASK] token.
+
+This demonstrates how to use vLLM with an encoder model such as BERT
+for a repeated classification task. A static prefix is combined with
+variable tokens and a final ``[MASK]`` token. The script repeatedly
+runs the model and prints the probability for the positive class after
+applying a sigmoid to the raw logit of the ``[MASK]`` position.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+from typing import Iterable
+
+import torch
+from transformers import AutoTokenizer
+
+from vllm import LLM, EngineArgs
+from vllm.utils import FlexibleArgumentParser
+
+
+_DEF_MODEL = "bert-base-uncased"
+
+
+def _read_lines(fp: Path) -> Iterable[str]:
+    if not fp.exists():
+        return []
+    with fp.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield line
+
+
+def parse_args():
+    parser = FlexibleArgumentParser()
+    parser = EngineArgs.add_cli_args(parser)
+    parser.add_argument(
+        "--static-prefix",
+        type=str,
+        default="",
+        help="Text that forms the first 400 tokens of every prompt.",
+    )
+    parser.add_argument(
+        "--variable-file",
+        type=Path,
+        default=None,
+        help="Optional file with one variable prompt per line.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1000,
+        help="Number of iterations to run.",
+    )
+    parser.set_defaults(
+        model=_DEF_MODEL,
+        task="classify",
+        enforce_eager=True,
+        override_pooler_config="{\"softmax\": false}",
+    )
+    return parser.parse_args()
+
+
+def main(args: Namespace) -> None:
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    mask_id = tokenizer.mask_token_id
+    if mask_id is None:
+        raise ValueError("The tokenizer does not define a [MASK] token.")
+
+    prefix_ids = tokenizer(args.static_prefix, add_special_tokens=False)[
+        "input_ids"]
+
+    if args.variable_file:
+        variable_texts = list(_read_lines(args.variable_file))
+    else:
+        variable_texts = [f"iteration {i}" for i in range(args.iterations)]
+
+    llm = LLM(**vars(args))
+
+    for i, text in enumerate(variable_texts[: args.iterations]):
+        variable_ids = tokenizer(text, add_special_tokens=False)["input_ids"]
+        input_ids = prefix_ids + variable_ids
+        input_ids = input_ids[:511]
+        input_ids.append(mask_id)
+        prompt = tokenizer.decode(input_ids)
+
+        (output,) = llm.classify(prompt)
+        logits = output.outputs.probs
+        if not logits:
+            raise RuntimeError("Received empty logits from model.")
+        prob = torch.sigmoid(torch.tensor(logits[0])).item()
+        print(f"Step {i}: P=\u007bprob:.4f\u007d")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
## Summary
- add script `token_mask_classification.py` showing repeated inference on a final `[MASK]` token with BERT
- document the workflow in `pooling_models.md`
- reference the example from `README`

## Testing
- `pre-commit` *(failed: `pre-commit: command not found`)*